### PR TITLE
support access token in cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ work with this project.
     ```
     # change this to your desired issuer in jwt
     jwt.issuer=joejoe2.com
-    
+   
+    # domain for access/refresh tokens in cookie(if you are using web login api)
+    # can be exact domain or .example.com for all subdomains
+    jwt.cookie.domain=.example.com
+
     # specify lifetime of access and refresh token in seconds
     jwt.access.token.lifetime=900
     jwt.refresh.token.lifetime=1800

--- a/env/application.env.example
+++ b/env/application.env.example
@@ -20,6 +20,9 @@ default.admin.email=admin@email.com
 
 # jwt related settings
 jwt.issuer=joejoe2.com
+# domain for access/refresh tokens in cookie(if you are using web login api)
+# can be exact domain or .example.com for all subdomains
+jwt.cookie.domain=.example.com
 jwt.secret.privateKey=
 jwt.secret.publicKey=
 # in seconds

--- a/src/main/java/com/joejoe2/demo/config/JwtConfig.java
+++ b/src/main/java/com/joejoe2/demo/config/JwtConfig.java
@@ -23,4 +23,7 @@ public class JwtConfig {
 
   @Value("${jwt.issuer:issuer}")
   private String issuer;
+
+  @Value("${jwt.cookie.domain:.${jwt.issuer}}")
+  private String cookieDomain;
 }

--- a/src/main/java/com/joejoe2/demo/config/SpringDocConfig.java
+++ b/src/main/java/com/joejoe2/demo/config/SpringDocConfig.java
@@ -5,14 +5,24 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(info = @Info(title = "Spring JWT Template API", version = "v0.0.1"))
-@SecurityScheme(
-    name = "jwt",
-    scheme = "bearer",
-    bearerFormat = "jwt",
-    type = SecuritySchemeType.HTTP,
-    in = SecuritySchemeIn.HEADER)
+@SecuritySchemes({
+  @SecurityScheme(
+      name = "jwt",
+      scheme = "bearer",
+      bearerFormat = "jwt",
+      type = SecuritySchemeType.HTTP,
+      in = SecuritySchemeIn.HEADER),
+  @SecurityScheme(
+      name = "jwt-in-cookie",
+      paramName = "access_token",
+      scheme = "bearer",
+      bearerFormat = "jwt",
+      type = SecuritySchemeType.HTTP,
+      in = SecuritySchemeIn.COOKIE)
+})
 @Configuration
 public class SpringDocConfig {}

--- a/src/main/java/com/joejoe2/demo/controller/AdminController.java
+++ b/src/main/java/com/joejoe2/demo/controller/AdminController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import javax.validation.Valid;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +42,10 @@ public class AdminController {
       summary = "change the role of target user",
       description = "this is only allowed to ADMIN")
   @ApiAllowsTo(roles = Role.ADMIN)
-  @SecurityRequirement(name = "jwt")
+  @SecurityRequirements({
+    @SecurityRequirement(name = "jwt"),
+    @SecurityRequirement(name = "jwt-in-cookie")
+  })
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -86,7 +90,10 @@ public class AdminController {
 
   @Operation(summary = "activate target user", description = "this is only allowed to ADMIN")
   @ApiAllowsTo(roles = Role.ADMIN)
-  @SecurityRequirement(name = "jwt")
+  @SecurityRequirements({
+    @SecurityRequirement(name = "jwt"),
+    @SecurityRequirement(name = "jwt-in-cookie")
+  })
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -130,7 +137,10 @@ public class AdminController {
 
   @Operation(summary = "deactivate target user", description = "this is only allowed to ADMIN")
   @ApiAllowsTo(roles = Role.ADMIN)
-  @SecurityRequirement(name = "jwt")
+  @SecurityRequirements({
+    @SecurityRequirement(name = "jwt"),
+    @SecurityRequirement(name = "jwt-in-cookie")
+  })
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -176,7 +186,10 @@ public class AdminController {
       summary = "get all user profiles with page param",
       description = "this is only allowed to ADMIN")
   @ApiAllowsTo(roles = Role.ADMIN)
-  @SecurityRequirement(name = "jwt")
+  @SecurityRequirements({
+    @SecurityRequirement(name = "jwt"),
+    @SecurityRequirement(name = "jwt-in-cookie")
+  })
   @ApiResponses(
       value = {
         @ApiResponse(

--- a/src/main/java/com/joejoe2/demo/controller/UserController.java
+++ b/src/main/java/com/joejoe2/demo/controller/UserController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,10 @@ public class UserController {
       summary = "get profile of login user",
       description = "this is allowed to any authenticated user")
   @AuthenticatedApi
-  @SecurityRequirement(name = "jwt")
+  @SecurityRequirements({
+    @SecurityRequirement(name = "jwt"),
+    @SecurityRequirement(name = "jwt-in-cookie")
+  })
   @ApiResponses(
       value = {
         @ApiResponse(

--- a/src/main/java/com/joejoe2/demo/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/joejoe2/demo/filter/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import com.joejoe2.demo.service.jwt.JwtService;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -29,6 +31,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // auth by header
     String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
     if (authHeader != null) accessToken = authHeader.replace("Bearer ", "");
+
+    // auth by cookie
+    if (accessToken == null) {
+      Cookie cookie = WebUtils.getCookie(request, "access_token");
+      if (cookie != null && cookie.getValue() != null) accessToken = cookie.getValue();
+    }
 
     // try to auth
     if (accessToken != null) {

--- a/src/main/java/com/joejoe2/demo/utils/CookieUtils.java
+++ b/src/main/java/com/joejoe2/demo/utils/CookieUtils.java
@@ -3,9 +3,21 @@ package com.joejoe2.demo.utils;
 import javax.servlet.http.Cookie;
 
 public class CookieUtils {
-  public static Cookie create(String key, String value, int maxAge, boolean isHttpOnly) {
+  public static Cookie create(
+      String key, String value, String domain, int maxAge, boolean isHttpOnly) {
     Cookie cookie = new Cookie(key, value);
     cookie.setMaxAge(maxAge);
+    cookie.setDomain(domain);
+    cookie.setPath("/");
+    cookie.setHttpOnly(isHttpOnly);
+    return cookie;
+  }
+
+  public static Cookie removed(String key, String domain, boolean isHttpOnly) {
+    Cookie cookie = new Cookie(key, null);
+    cookie.setMaxAge(0);
+    cookie.setDomain(domain);
+    cookie.setPath("/");
     cookie.setHttpOnly(isHttpOnly);
     return cookie;
   }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -18,6 +18,9 @@ default.admin.password=pa55ward
 default.admin.email=admin@email.com
 # jwt related settings
 jwt.issuer=joejoe2.com
+# domain for access/refresh tokens in cookie(if you are using web login api)
+# can be exact domain or .example.com for all subdomains
+jwt.cookie.domain=localhost
 # in seconds
 jwt.access.token.lifetime=900
 jwt.refresh.token.lifetime=1800

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -21,6 +21,9 @@ default.admin.password=pa55ward
 default.admin.email=admin@email.com
 # jwt related settings
 jwt.issuer=joejoe2.com
+# domain for access/refresh tokens in cookie(if you are using web login api)
+# can be exact domain or .example.com for all subdomains
+jwt.cookie.domain=.example.com
 # in seconds
 jwt.access.token.lifetime=900
 jwt.refresh.token.lifetime=1800


### PR DESCRIPTION
- webLogin and webRefresh APIs will set access/refresh tokens in http-only cookie (but still return access token in response body)
- logout API will clear access/refresh tokens in http-only cookie
- access token can be placed at "Authorization" header or "access_token" cookie for authentication 
- add new property(env variable) "jwt.cookie.domain"
  ```
  # domain for access/refresh tokens in cookie(if you are using web login api)
  # can be exact domain or .example.com for all subdomains
  jwt.cookie.domain=.example.com
  ```